### PR TITLE
feat: extract thinking content from content tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ Thumbs.db
 # Local config files with secrets
 config.local.toml
 *.local.toml
+
+# Git worktrees
+.worktrees/
+worktrees/

--- a/src/local_openai2anthropic/streaming/handler.py
+++ b/src/local_openai2anthropic/streaming/handler.py
@@ -241,10 +241,17 @@ async def _stream_response(
                     # Process content to extract thinking tags
                     # Some models (e.g., GLM-4.7) return thinking as标签 in content
                     while content_buffer:
-                        # Check if we should start a thinking block
+                        # Check if we have a complete thinking tag
                         thinking_start = content_buffer.find("<think>")
-                        if thinking_start == -1:
-                            # No thinking start tag, emit all as text
+                        thinking_end = content_buffer.find("</think>")
+
+                        logger.debug(
+                            f"[Thinking Extraction] content_buffer={repr(content_buffer)}, "
+                            f"thinking_start={thinking_start}, thinking_end={thinking_end}"
+                        )
+
+                        if thinking_start == -1 and thinking_end == -1:
+                            # No thinking tags at all, emit all as text
                             if content_buffer:
                                 if not content_block_started or current_block_type != "text":
                                     # Close previous block if exists
@@ -279,6 +286,47 @@ async def _stream_response(
                                 yield f"event: content_block_delta\ndata: {json.dumps(delta_block)}\n\n"
                             break
 
+                        # If we have thinking_start but no thinking_end, buffer until we get complete tag
+                        if thinking_start != -1 and thinking_end == -1:
+                            # Buffer the content and wait for more
+                            pending_text_prefix = content_buffer
+                            break
+
+                        # If thinking_end comes before thinking_start (or no thinking_start), handle it
+                        if thinking_end != -1 and (thinking_start == -1 or thinking_end < thinking_start):
+                            # There's text before the thinking end tag (orphan end tag)
+                            # This shouldn't happen normally, but handle gracefully
+                            if thinking_start == -1:
+                                # No start tag but have end tag - treat as text
+                                if content_buffer[:thinking_end]:
+                                    if not content_block_started or current_block_type != "text":
+                                        if content_block_started:
+                                            stop_block = {
+                                                "type": "content_block_stop",
+                                                "index": content_block_index,
+                                            }
+                                            yield f"event: content_block_stop\ndata: {json.dumps(stop_block)}\n\n"
+                                            content_block_index += 1
+                                        start_block = {
+                                            "type": "content_block_start",
+                                            "index": content_block_index,
+                                            "content_block": {"type": "text", "text": ""},
+                                        }
+                                        yield f"event: content_block_start\ndata: {json.dumps(start_block)}\n\n"
+                                        content_block_started = True
+                                        current_block_type = "text"
+
+                                    delta_block = {
+                                        "type": "content_block_delta",
+                                        "index": content_block_index,
+                                        "delta": {"type": "text_delta", "text": content_buffer[:thinking_end]},
+                                    }
+                                    yield f"event: content_block_delta\ndata: {json.dumps(delta_block)}\n\n"
+
+                                content_buffer = content_buffer[thinking_end + len("</think>"):]
+                                continue
+
+                        # We have both start and end tags
                         # Emit text before thinking tag as text block
                         if thinking_start > 0:
                             text_before = content_buffer[:thinking_start]
@@ -314,18 +362,11 @@ async def _stream_response(
                                 }
                                 yield f"event: content_block_delta\ndata: {json.dumps(delta_block)}\n\n"
 
-                        # Find thinking end tag
-                        content_buffer = content_buffer[thinking_start + len("<think>"):]
-                        thinking_end = content_buffer.find("</think>")
-
-                        if thinking_end == -1:
-                            # Thinking tag not complete, buffer the rest
-                            pending_text_prefix = "<think>" + content_buffer
-                            break
-
-                        # Extract thinking content
-                        thinking_content = content_buffer[:thinking_end]
-                        content_buffer = content_buffer[thinking_end + len("</think>"):]
+                        # Extract thinking content (between标签)
+                        thinking_content = content_buffer[
+                            thinking_start + len("<think>") : thinking_end
+                        ]
+                        content_buffer = content_buffer[thinking_end + len("</think>") :]
 
                         # Close previous text block if exists
                         if content_block_started and current_block_type == "text":

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -16,6 +16,7 @@ from local_openai2anthropic.converter import (
     _strip_claude_billing_header,
     convert_anthropic_to_openai,
     convert_openai_to_anthropic,
+    extract_thinking_from_content,
 )
 from local_openai2anthropic.protocol import UsageWithCache
 
@@ -411,6 +412,200 @@ class TestOpenAIToAnthropic:
         assert usage.output_tokens == 50
         assert usage.cache_creation_input_tokens == 200
         assert usage.cache_read_input_tokens == 300
+
+
+class TestExtractThinkingFromContent:
+    """Tests for thinking content extraction from content string."""
+
+    def test_extract_thinking_from_content_basic(self):
+        """Test basic thinking tag extraction."""
+        content = "<think>用户用中文说'你好'，这是一个简单的问题。我应该用中文友好地回应。\n</think>\n\n你好！很高兴见到你。"
+        thinking_blocks, clean_content = extract_thinking_from_content(content)
+
+        assert len(thinking_blocks) == 1
+        assert "用户用中文说'你好'" in thinking_blocks[0]
+        assert clean_content == "\n\n你好！很高兴见到你。"
+
+    def test_extract_thinking_from_content_no_thinking(self):
+        """Test content without thinking tags."""
+        content = "Hello! How can I help you?"
+        thinking_blocks, clean_content = extract_thinking_from_content(content)
+
+        assert len(thinking_blocks) == 0
+        assert clean_content == "Hello! How can I help you?"
+
+    def test_extract_thinking_from_content_multiple_blocks(self):
+        """Test multiple thinking blocks."""
+        content = "<think>第一步思考</think>中间文本<think>第二步思考</think>"
+        thinking_blocks, clean_content = extract_thinking_from_content(content)
+
+        assert len(thinking_blocks) == 2
+        assert "第一步思考" in thinking_blocks[0]
+        assert "第二步思考" in thinking_blocks[1]
+        assert clean_content == "中间文本"
+
+    def test_extract_thinking_from_content_empty_thinking(self):
+        """Test empty thinking tags."""
+        content = "<think></think>中间文本"
+        thinking_blocks, clean_content = extract_thinking_from_content(content)
+
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0] == ""
+        assert clean_content == "中间文本"
+
+    def test_extract_thinking_from_content_empty(self):
+        """Test empty content."""
+        thinking_blocks, clean_content = extract_thinking_from_content("")
+        assert len(thinking_blocks) == 0
+        assert clean_content == ""
+
+    def test_extract_thinking_from_content_none(self):
+        """Test None content."""
+        thinking_blocks, clean_content = extract_thinking_from_content(None)
+        assert len(thinking_blocks) == 0
+        assert clean_content == ""
+
+
+class TestOpenAIToAnthropicWithThinkingTags:
+    """Tests for OpenAI to Anthropic conversion with thinking tags in content."""
+
+    def test_thinking_tags_extracted_from_content(self):
+        """Test that thinking tags in content are extracted to thinking blocks."""
+        completion = ChatCompletion(
+            id="test-id",
+            model="glm-4.7",
+            object="chat.completion",
+            created=1234567890,
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content="<think>用户说'你好'，我应该用中文回应。\n</think>\n\n你好！很高兴见到你。",
+                        reasoning_content=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+            ),
+        )
+
+        result = convert_openai_to_anthropic(completion, "glm-4.7")
+
+        # Should have 2 content blocks: thinking and text
+        assert len(result.content) == 2
+
+        # First block should be thinking
+        assert result.content[0].type == "thinking"
+        assert "用户说'你好'" in result.content[0].thinking
+
+        # Second block should be text (with thinking tags removed)
+        assert result.content[1].type == "text"
+        assert "你好！很高兴见到你。" in result.content[1].text
+        assert "<think>" not in result.content[1].text
+
+    def test_no_thinking_tags_unchanged(self):
+        """Test that content without thinking tags is unchanged."""
+        completion = ChatCompletion(
+            id="test-id",
+            model="gpt-4o",
+            object="chat.completion",
+            created=1234567890,
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content="Hello! How can I help?",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+            ),
+        )
+
+        result = convert_openai_to_anthropic(completion, "gpt-4o")
+
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        assert result.content[0].text == "Hello! How can I help?"
+
+    def test_reasoning_content_takes_precedence(self):
+        """Test that reasoning_content field takes precedence over content tags."""
+        completion = ChatCompletion(
+            id="test-id",
+            model="glm-4.7",
+            object="chat.completion",
+            created=1234567890,
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content="<think>这应该在reasoning_content中</think>",
+                        reasoning_content="这是reasoning_content字段的内容",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+            ),
+        )
+
+        result = convert_openai_to_anthropic(completion, "glm-4.7")
+
+        # Should use reasoning_content, not content tags
+        assert len(result.content) == 1
+        assert result.content[0].type == "thinking"
+        assert result.content[0].thinking == "这是reasoning_content字段的内容"
+
+    def test_multiple_thinking_blocks(self):
+        """Test multiple thinking blocks in content."""
+        completion = ChatCompletion(
+            id="test-id",
+            model="glm-4.7",
+            object="chat.completion",
+            created=1234567890,
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content="<think>第一步思考</think>中间内容<think>第二步思考</think>",
+                        reasoning_content=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+            ),
+        )
+
+        result = convert_openai_to_anthropic(completion, "glm-4.7")
+
+        # Should have 3 content blocks: thinking, thinking, text
+        # (all thinking blocks are grouped first, then text)
+        assert len(result.content) == 3
+        assert result.content[0].type == "thinking"
+        assert "第一步思考" in result.content[0].thinking
+        assert result.content[1].type == "thinking"
+        assert "第二步思考" in result.content[1].thinking
+        assert result.content[2].type == "text"
+        assert result.content[2].text == "中间内容"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `extract_thinking_from_content()` function to parse `<think>...</think>` tags from content
- Update `convert_openai_to_anthropic()` to extract thinking from content tags when `reasoning_content` is not available
- Update streaming handler to buffer chunks and detect complete thinking tags, then emit proper Anthropic thinking block events

Some models (e.g., GLM-4.7) return thinking content embedded in the content field as `<think>...</think>` tags instead of using the dedicated `reasoning_content` field. This change ensures these thinking tags are properly extracted and converted to Anthropic's native thinking block format.

## Test plan

- [x] Run converter unit tests: 29 tests passing
- [x] Test with GLM-4.7 streaming API - thinking content correctly extracted
- [x] Verify non-streaming response conversion
- [x] Verify streaming response conversion